### PR TITLE
Change `errorMessages` to an optional property

### DIFF
--- a/src/components/Camera/types.ts
+++ b/src/components/Camera/types.ts
@@ -9,7 +9,7 @@ export interface CameraProps {
   facingMode?: FacingMode;
   aspectRatio?: AspectRatio;
   numberOfCamerasCallback?(numberOfCameras: number): void;
-  errorMessages: {
+  errorMessages?: {
     noCameraAccessible?: string;
     permissionDenied?: string;
     switchCamera?: string;


### PR DESCRIPTION
In [the docs](https://www.npmjs.com/package/react-camera-pro), I see that `errorMessages` is supposed to be optional, but in the component interface it is required.