### PR TITLE
Add a video loaded callback to track loading

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -164,6 +164,9 @@ const App = () => {
               'It is not possible to switch camera to different one because there is only one video device accessible.',
             canvas: 'Canvas is not supported.',
           }}
+          videoReadyCallback={() => {
+            console.log('Video feed ready.');
+          }}
         />
       )}
       <Control>

--- a/example/src/Camera/components/Camera/types.d.ts
+++ b/example/src/Camera/components/Camera/types.d.ts
@@ -17,6 +17,7 @@ export interface CameraProps {
         switchCamera?: string;
         canvas?: string;
     };
+    videoReadyCallback?(): void;
 }
 export declare type CameraType = React.ForwardRefExoticComponent<CameraProps & React.RefAttributes<unknown>> & {
     takePhoto(): string;

--- a/src/components/Camera/Camera.tsx
+++ b/src/components/Camera/Camera.tsx
@@ -24,6 +24,7 @@ export const Camera = React.forwardRef<unknown, CameraProps>(
           'It is not possible to switch camera to different one because there is only one video device accessible.',
         canvas: 'Canvas is not supported.',
       },
+      videoReadyCallback = () => null,
     },
     ref,
   ) => {
@@ -135,6 +136,9 @@ export const Camera = React.forwardRef<unknown, CameraProps>(
             autoPlay={true}
             playsInline={true}
             mirrored={currentFacingMode === 'user' ? true : false}
+            onLoadedData={() => {
+              videoReadyCallback();
+            }}
           ></Cam>
           <Canvas ref={canvas} />
         </Wrapper>

--- a/src/components/Camera/types.ts
+++ b/src/components/Camera/types.ts
@@ -16,6 +16,7 @@ export interface CameraProps {
     switchCamera?: string;
     canvas?: string;
   };
+  videoReadyCallback?(): void;
 }
 
 export type CameraType = React.ForwardRefExoticComponent<CameraProps & React.RefAttributes<unknown>> & {


### PR DESCRIPTION
<img width="674" alt="Screenshot 2023-04-06 at 2 47 47 PM" src="https://user-images.githubusercontent.com/86255078/230490883-fd8e3fef-d54e-4889-b49a-35d80d650388.png">

## Description

This change adds a new optional component property called `videoReadyCallback`, which is fired whenever the video stream is ready for use. This property allows developers to efficiently track the status of the camera feed, allowing for usage of loading states by parent components while the camera stream is setting up.

## Changes

- Added a new property called 'videoReadyCallback' which is fired on data loaded (see References for usage).
- Updated the example project to demonstrate usage of the event handler.

## Testing

- Tested on local environment, screenshot is attached.

## References

- https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/loadeddata_event