### PR TITLE
Fix the width of the image in the preview video element on iOS 17.2.1.

### DIFF
--- a/src/components/Camera/Camera.tsx
+++ b/src/components/Camera/Camera.tsx
@@ -170,8 +170,6 @@ const initCameraStream = (
     video: {
       deviceId: videoSourceDeviceId ? { exact: videoSourceDeviceId } : undefined,
       facingMode: currentFacingMode,
-      width: { ideal: 1920 },
-      height: { ideal: 1920 },
     },
   };
 


### PR DESCRIPTION
This PR corrects the following issue seen on iOS 17.2.1:  https://github.com/purple-technology/react-camera-pro/issues/50

I'm not sure whether the ideal width and height are required for some other particular context, but removing them does fix this particular iOS issue.