### PR TITLE
Change errorMessages in props to optional

### DIFF
--- a/src/components/Camera/Camera.tsx
+++ b/src/components/Camera/Camera.tsx
@@ -10,6 +10,14 @@ import {
 } from './types';
 import { Container, Wrapper, Canvas, Cam, ErrorMsg } from './styles';
 
+const defaultErrorMessages = {
+  noCameraAccessible: 'No camera device accessible. Please connect your camera or try a different browser.',
+  permissionDenied: 'Permission denied. Please refresh and give camera permission.',
+  switchCamera:
+    'It is not possible to switch camera to different one because there is only one video device accessible.',
+  canvas: 'Canvas is not supported.',
+};
+
 export const Camera = React.forwardRef<unknown, CameraProps>(
   (
     {
@@ -17,13 +25,7 @@ export const Camera = React.forwardRef<unknown, CameraProps>(
       aspectRatio = 'cover',
       numberOfCamerasCallback = () => null,
       videoSourceDeviceId = undefined,
-      errorMessages = {
-        noCameraAccessible: 'No camera device accessible. Please connect your camera or try a different browser.',
-        permissionDenied: 'Permission denied. Please refresh and give camera permission.',
-        switchCamera:
-          'It is not possible to switch camera to different one because there is only one video device accessible.',
-        canvas: 'Canvas is not supported.',
-      },
+      errorMessages: propsErrorMessages = defaultErrorMessages,
       videoReadyCallback = () => null,
     },
     ref,
@@ -40,6 +42,7 @@ export const Camera = React.forwardRef<unknown, CameraProps>(
     const [torchSupported, setTorchSupported] = useState<boolean>(false);
     const [torch, setTorch] = useState<boolean>(false);
     const mounted = useRef(false);
+    const errorMessages = { ...defaultErrorMessages, ...propsErrorMessages };
 
     useEffect(() => {
       mounted.current = true;

--- a/src/components/Camera/types.ts
+++ b/src/components/Camera/types.ts
@@ -10,7 +10,7 @@ export interface CameraProps {
   aspectRatio?: AspectRatio;
   numberOfCamerasCallback?(numberOfCameras: number): void;
   videoSourceDeviceId?: string | undefined;
-  errorMessages: {
+  errorMessages?: {
     noCameraAccessible?: string;
     permissionDenied?: string;
     switchCamera?: string;


### PR DESCRIPTION
## Issue

resolve #63 

## Description

The errorMessages in props was not set to optional and has been corrected.

- before
```tsx
<Camera /> // ❌ error: Property 'errorMessages' is missing in type '{ ref: RefObject<CameraType>; aspectRatio: number; }' but required in type 'CameraProps'.
```
- after
```tsx
<Camera /> // ⭕ ok
```

---

Also, I think it has been fixed that if each property of the errorMessages object was omitted, it did not work correctly internally.

- before
```tsx
<Camera errorMessages={{}} /> // errorMessages.noCameraAccessible <- string | undefined (inside component) ❌
```
- after
```tsx
<Camera errorMessages={{}} /> // errorMessages.noCameraAccessible <- string (inside component) ⭕
```